### PR TITLE
Min and max duration filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ OPTIONS:
     --allrides-file <path>
         Specifies the path to the JSON file that describes all the available
         rides in the library.
+    --category <name>
+        Only include rides from the specified category. The name
+        match is case-insensitive and liberal: e.g. specifying "hill"
+        will match all rides contained in the category "Hilly".
     --contributor <name>
         Only include rides submitted by the specified contributor. The name
         match is case-insensitive and liberal: e.g. specifying "mourier"

--- a/README.md
+++ b/README.md
@@ -88,9 +88,15 @@ OPTIONS:
     --max-distance <value>
         Only include rides with a distance (in Km's) up to the specified
         value.
+    --max-duration <value>
+        Only include rides with a duration (in minutes) up to the specified
+        value.
     --max-elevation-gain <value>
         Only include rides with an elevation gain (in meters) up to the
         specified value.
+    --min-duration <value>
+        Only include rides with a duration (in minutes) from the specified
+        value.
     --output-format {csv|html|text}
         Specifies the format of the output file with the list of routes.
         If omitted, the plain text format is used by default.

--- a/args.h
+++ b/args.h
@@ -34,4 +34,6 @@ typedef struct CmdArgs {
     int dlProg;
     int maxDistance;
     int maxElevGain;
+    int minDuration;
+    int maxDuration;
 } CmdArgs;

--- a/main.c
+++ b/main.c
@@ -6,10 +6,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/queue.h>
-#include <unistd.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
+
+#include <unistd.h>
+
 #include <curl/curl.h>
 
 #include "args.h"

--- a/main.c
+++ b/main.c
@@ -98,6 +98,10 @@ static const char *help =
         "    --allrides-file <path>\n"
         "        Specifies the path to the JSON file that describes all the available\n"
         "        rides in the library.\n"
+        "    --category <name>\n"
+        "        Only include rides from the specified category. The name\n"
+        "        match is case-insensitive and liberal: e.g. specifying \"hill\"\n"
+        "        will match all rides contained in the category \"Hilly\".\n"       
         "    --contributor <name>\n"
         "        Only include rides submitted by the specified contributor. The name\n"
         "        match is case-insensitive and liberal: e.g. specifying \"mourier\"\n"
@@ -169,8 +173,10 @@ static int parseCmdArgs(int argc, char *argv[], CmdArgs *pArgs)
             exit(0);
         } else if (strcmp(arg, "--allrides-file") == 0) {
             pArgs->inFile = argv[++n];
+        } else if (strcmp(arg, "--category") == 0) {
+            pArgs->category = argv[++n];                        
         } else if (strcmp(arg, "--contributor") == 0) {
-            pArgs->contributor = argv[++n];
+            pArgs->contributor = argv[++n];            
         } else if (strcmp(arg, "--country") == 0) {
             pArgs->country = argv[++n];
         } else if (strcmp(arg, "--download-folder") == 0) {
@@ -381,6 +387,10 @@ static char *stristr(const char *s1, const char *s2 )
 
 static int applyMatchFilters(const RouteInfo *pInfo, const CmdArgs *pArgs)
 {
+    if ((pArgs->category != NULL) && (stristr(pInfo->categories, pArgs->category) == NULL)) {
+        // Ignore this ride...
+        return -1;
+    }
     if ((pArgs->contributor != NULL) && (stristr(pInfo->contributor, pArgs->contributor) == NULL)) {
         // Ignore this ride...
         return -1;

--- a/output.c
+++ b/output.c
@@ -105,20 +105,17 @@ static char *fmtProvince(const char *location)
 
     return fmtBuf;
 }
-// A few routes include a comma in their description which
-// screws up the CSV output format...
-
-
-
+// The categories contain all the json parts
+// ["New", "Hilly", "etc" ]
 void remove_char(char *n, char *s, char c) {   
     while (*s) {                            
-        if (*s != c)                        // test if char is to be removed
-            *n++ = *s;                      // copy if not
-        s++;                                // advance source pointer
+        if (*s != c)
+            *n++ = *s;
+        s++;          
     }
-    *n = '\0';                              // terminate new string
+    *n = '\0';                             
 }
-void replace_char(char *n, char *s, char c, char nc) {   // renamed because remove() is predefined
+void replace_char(char *n, char *s, char c, char nc) { 
     while (*s) {                            
         if (*s == c) {                       
             *n++ = nc;
@@ -128,9 +125,8 @@ void replace_char(char *n, char *s, char c, char nc) {   // renamed because remo
             *n++ = *s++;
         }                      
     }
-    *n = '\0';                              // terminate new string
+    *n = '\0';                             
 }
-
 static char *fmtCategories(const char *categories)
 {
 //    char *p;

--- a/output.c
+++ b/output.c
@@ -105,6 +105,46 @@ static char *fmtProvince(const char *location)
 
     return fmtBuf;
 }
+// A few routes include a comma in their description which
+// screws up the CSV output format...
+
+
+
+void remove_char(char *n, char *s, char c) {   
+    while (*s) {                            
+        if (*s != c)                        // test if char is to be removed
+            *n++ = *s;                      // copy if not
+        s++;                                // advance source pointer
+    }
+    *n = '\0';                              // terminate new string
+}
+void replace_char(char *n, char *s, char c, char nc) {   // renamed because remove() is predefined
+    while (*s) {                            
+        if (*s == c) {                       
+            *n++ = nc;
+            s++;
+        }
+        else {
+            *n++ = *s++;
+        }                      
+    }
+    *n = '\0';                              // terminate new string
+}
+
+static char *fmtCategories(const char *categories)
+{
+//    char *p;
+    static char fmtBuf[128];
+
+    snprintf(fmtBuf, sizeof (fmtBuf), "%s", categories);
+    remove_char(fmtBuf, fmtBuf, '[');
+    remove_char(fmtBuf, fmtBuf, ']');
+    remove_char(fmtBuf, fmtBuf, '"');
+    replace_char(fmtBuf, fmtBuf, ',', '/');
+    return fmtBuf;
+}
+
+
 
 // Format time as HH:MM:SS
 static char *fmtTime(int time)
@@ -125,6 +165,7 @@ static const char *cellName[] = {
         "Country",
         "Province/State",
         "Contributor",
+        "Categories", 
         "Distance",
         "Elevation Gain",
         "Duration",
@@ -150,6 +191,7 @@ void printCsvOutput(const RouteDB *pDb)
         printf("%s,", fmtCountry(pRoute->location));
         printf("%s,", fmtProvince(pRoute->location));
         printf("%s,", pRoute->contributor);
+        printf("%s,", fmtCategories(pRoute->categories));
         printf("%s,", pRoute->distance);
         printf("%s,", pRoute->elevation);
         printf("%s,", fmtTime(pRoute->time));
@@ -206,6 +248,7 @@ void printHttpOutput(const RouteDB *pDb)
         printStringCellValue(fmtCountry(pRoute->location), 0);
         printStringCellValue(fmtProvince(pRoute->location), 0);
         printStringCellValue(pRoute->contributor, 0);
+        printStringCellValue(fmtCategories(pRoute->categories), 0);
         printStringCellValue(pRoute->distance, 0);
         printStringCellValue(pRoute->elevation, 0);
         printStringCellValue(fmtTime(pRoute->time), 0);
@@ -236,6 +279,7 @@ void printTextOutput(const RouteDB *pDb)
         printf("    Country:         %s\n", fmtCountry(pRoute->location));
         printf("    Province/State:  %s\n", fmtProvince(pRoute->location));
         printf("    Contributor:     %s\n", pRoute->contributor);
+        printf("    Categories:      %s\n", fmtCategories(pRoute->categories));        
         printf("    Distance:        %s\n", pRoute->distance);
         printf("    Elevation Gain:  %s\n", pRoute->elevation);
         printf("    Duration:        %s\n", fmtTime(pRoute->time));


### PR DESCRIPTION
Hi,

i added some duration filters, because i needed them. ;-)
I have some workouts with a defined time and now i can find matching rides easily.

The include was needed for the Raspberry Pi. I also needed to remove the option -m64 in the Makefile to get it compiled on the Raspberry. At least on the Pi with 32 Bit Raspbian libcurl is only able to fetch files with max. 2GB size.

The filter elements are added alphabetically except for the args struct. Within the struct, the order is semantic.

Categories output is added as well, simple removing of '[', '"' and ']'. Comma is replaced by "/"

Thanks for all your work!

Joachim